### PR TITLE
Fix for game phase resetting in singleplayer

### DIFF
--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/block/common/BasePotBlock.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/block/common/BasePotBlock.java
@@ -328,7 +328,7 @@ public class BasePotBlock extends Block implements SimpleWaterloggedBlock {
     private boolean dropAmmo(ServerLevel level, Vec3 center) {
         int amount = level.random.nextInt(10, 21);
         Item item = Items.ARROW;
-        boolean isHardmode = KillBoard.INSTANCE.getGamePhase().isHardmode();
+        boolean isHardmode = KillBoard.INSTANCE.getGamePhase(level).isHardmode();
         if (level.random.nextBoolean()) {
             item = isHardmode ? ConsumableItems.GRENADE.get() : ConsumableItems.SHURIKEN.get();
         } else if (level.dimension() == Level.NETHER) {
@@ -346,7 +346,7 @@ public class BasePotBlock extends Block implements SimpleWaterloggedBlock {
 
     private boolean dropHeal(ServerLevel level, BlockPos blockPos, Vec3 center) {
         Item item;
-        if (level.dimension() == Level.NETHER || KillBoard.INSTANCE.getGamePhase().isHardmode()) {
+        if (level.dimension() == Level.NETHER || KillBoard.INSTANCE.getGamePhase(level).isHardmode()) {
             item = PotionItems.HEALING_POTION.get();
         } else {
             item = PotionItems.LESSER_HEALING_POTION.get();
@@ -373,7 +373,7 @@ public class BasePotBlock extends Block implements SimpleWaterloggedBlock {
     }
 
     private boolean dropRope(ServerLevel level, BlockPos blockPos, Vec3 center) {
-        if (level.dimension() == Level.NETHER || KillBoard.INSTANCE.getGamePhase().isHardmode()) {
+        if (level.dimension() == Level.NETHER || KillBoard.INSTANCE.getGamePhase(level).isHardmode()) {
             return dropMoney(level, blockPos, center);
         } else {
             LibUtils.createItemEntity(ModBlocks.ROPE.get().asItem(), level.random.nextInt(5, 11), center, level, 0);

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/block/natural/spreadable/ISpreadable.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/block/natural/spreadable/ISpreadable.java
@@ -43,7 +43,7 @@ public interface ISpreadable {
         if (!blockState.getValue(STILL_ALIVE)) return;
         int chance = serverLevel.getGameRules().getInt(Confluence.SPREADABLE_CHANCE);
         if (chance == 0 || randomSource.nextInt(100) >= chance) return;
-        int phase = KillBoard.INSTANCE.getGamePhase().ordinal();
+        int phase = KillBoard.INSTANCE.getGamePhase(serverLevel).ordinal();
         for (int i = 0; i < 4; ++i) {
             BlockPos targetPos = blockPos.offset(randomSource.nextInt(3) - 1, randomSource.nextInt(5) - 3, randomSource.nextInt(3) - 1);
             if (!serverLevel.isLoaded(targetPos)) continue;

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/ConfluenceCommand.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/ConfluenceCommand.java
@@ -60,7 +60,7 @@ public class ConfluenceCommand {
                 )
                 .then(Commands.literal("gamePhase")
                         .then(Commands.literal("get").executes(context -> {
-                            String gamePhase = KillBoard.INSTANCE.getGamePhase().getSerializedName();
+                            String gamePhase = KillBoard.INSTANCE.getGamePhase(context.getSource().getLevel()).getSerializedName();
                             context.getSource().sendSystemMessage(Component.literal("GamePhase: " + gamePhase));
                             return 1;
                         }))

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/saved/KillBoard.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/saved/KillBoard.java
@@ -10,6 +10,7 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.confluence.lib.common.data.saved.IGlobalData;
@@ -18,6 +19,8 @@ import org.confluence.mod.mixed.IMinecraftServer;
 import org.confluence.mod.mixed.IWorldOptions;
 import org.confluence.mod.network.s2c.GamePhasePacketS2C;
 import org.confluence.terraentity.init.entity.TEBossEntities;
+
+import javax.annotation.Nullable;
 
 public class KillBoard implements IGlobalData {
     public static final KillBoard INSTANCE = new KillBoard();
@@ -75,7 +78,11 @@ public class KillBoard implements IGlobalData {
     }
 
     public GamePhase getGamePhase() {
-        if (FMLEnvironment.dist.isClient()) {
+        return getGamePhase(null);
+    }
+
+    public GamePhase getGamePhase(@Nullable Level level) {
+        if (level != null && level.isClientSide) {
             return ClientPacketHandler.getGamePhase();
         }
         return gamePhase;

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/saved/NPCSpawner.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/saved/NPCSpawner.java
@@ -395,8 +395,8 @@ public class NPCSpawner implements IGlobalData {
 //                return spawnAtPos(serverPlayer.serverLevel(), pos, TENpcEntities.CLOTHIER.get());
 //            }
 //        }
-        if (!KillBoard.INSTANCE.getGamePhase().isAboveThan(GamePhase.BEFORE_SKELETRON)) {
-            ServerLevel level = serverPlayer.serverLevel();
+        ServerLevel level = serverPlayer.serverLevel();
+        if (!KillBoard.INSTANCE.getGamePhase(level).isAboveThan(GamePhase.BEFORE_SKELETRON)) {
             Structure structure = level.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ModStructures.DUNGEON_KEY);
             if (structure == null) return false;
 

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/recipe/ItemTransmutationRecipe.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/recipe/ItemTransmutationRecipe.java
@@ -25,7 +25,7 @@ public record ItemTransmutationRecipe(Ingredient source, List<ItemStack> target,
 
     @Override
     public boolean matches(SingleRecipeInput input, Level level) {
-        return input.item().getCount() >= shrink && source.test(input.item()) && KillBoard.INSTANCE.getGamePhase().ordinal() >= gamePhase.ordinal();
+        return input.item().getCount() >= shrink && source.test(input.item()) && KillBoard.INSTANCE.getGamePhase(level).ordinal() >= gamePhase.ordinal();
     }
 
     @Override

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/worldgen/structure/DungeonStructure.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/worldgen/structure/DungeonStructure.java
@@ -400,7 +400,7 @@ public class DungeonStructure extends Structure {
     }
 
     public static void checkSkeletronDefeated(ServerPlayer player, ServerLevel level) {
-        if (KillBoard.INSTANCE.getGamePhase() == GamePhase.BEFORE_SKELETRON && player.isAlive() && player.gameMode.getGameModeForPlayer().isSurvival() && level.getGameTime() % 100 == 1) {
+        if (KillBoard.INSTANCE.getGamePhase(level) == GamePhase.BEFORE_SKELETRON && player.isAlive() && player.gameMode.getGameModeForPlayer().isSurvival() && level.getGameTime() % 100 == 1) {
             Structure structure = level.registryAccess().registryOrThrow(Registries.STRUCTURE).get(ModStructures.DUNGEON_KEY);
             if (structure == null) return;
 

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/mixin/entity/EntityMixin.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/mixin/entity/EntityMixin.java
@@ -188,7 +188,7 @@ public abstract class EntityMixin implements IEntity, SelfGetter<Entity> {
     @Unique
     private static void confluence$initTarget(ShimmerEntityTransmutationEvent.Post event) {
         Entity sourceEntity = event.getSource();
-        GamePhase gamePhase = KillBoard.INSTANCE.getGamePhase();
+        GamePhase gamePhase = KillBoard.INSTANCE.getGamePhase(sourceEntity.level());
         for (ShimmerEntityTransmutationEvent.EntityTransmutation transmutation : ENTITY_TRANSMUTATION) {
             if (transmutation.gamePhase().isAboveThan(gamePhase)) continue;
             if (transmutation.source().test(sourceEntity)) {

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/mixin/entity/ItemEntityMixin.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/mixin/entity/ItemEntityMixin.java
@@ -107,7 +107,7 @@ public abstract class ItemEntityMixin implements IItemEntity {
         ItemEntity source = event.getSource();
         ItemStack sourceItem = source.getItem();
 
-        GamePhase gamePhase = KillBoard.INSTANCE.getGamePhase();
+        GamePhase gamePhase = KillBoard.INSTANCE.getGamePhase(source.level());
         List<RecipeHolder<ItemTransmutationRecipe>> recipes = source.level().getRecipeManager().getRecipesFor(ModRecipes.ITEM_TRANSMUTATION_TYPE.get(), new SingleRecipeInput(sourceItem), source.level());
         for (RecipeHolder<ItemTransmutationRecipe> recipeHolder : recipes) {
             ItemTransmutationRecipe recipe = recipeHolder.value();

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/util/PlayerUtils.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/util/PlayerUtils.java
@@ -117,7 +117,7 @@ public final class PlayerUtils {
         if (CommonConfigs.STAR_PHASE.get()) {
             StarPhasesPacketS2C.sendToClient(serverPlayer, data.getStarPhases());
         }
-        GamePhasePacketS2C.sendToClient(serverPlayer, KillBoard.INSTANCE.getGamePhase());
+        GamePhasePacketS2C.sendToClient(serverPlayer, KillBoard.INSTANCE.getGamePhase(serverPlayer.serverLevel()));
     }
 
     public static float getFishingPower(ServerPlayer player) {


### PR DESCRIPTION
As described [here](https://github.com/MagicHarp/confluence/issues/74#issuecomment-2906965598), `isClient()` check is not reliable, so I just added a Level argument and check against it instead.
Method without argument is retained for binary compatibility, but could be removed if not needed.