### PR TITLE
Datagen for table_exclusions.json

### DIFF
--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/EMILootDirectDropsProvider.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/EMILootDirectDropsProvider.java
@@ -49,8 +49,8 @@ public class EMILootDirectDropsProvider implements DataProvider {
 
     @Override
     public CompletableFuture<?> run(CachedOutput cachedOutput) {
-        return this.registries.thenCompose((p_323117_) -> {
-            return this.run(cachedOutput, p_323117_);
+        return this.registries.thenCompose((provider) -> {
+            return this.run(cachedOutput, provider);
         });
     }
 
@@ -95,8 +95,8 @@ public class EMILootDirectDropsProvider implements DataProvider {
         this.validate(lootTables, validationcontext);
         Multimap<String, String> multimap = problemreporter$Collector.get();
         if (!multimap.isEmpty()) {
-            multimap.forEach((p_124446_, p_124447_) -> {
-                LOGGER.warn("Found validation problem in {}: {}", p_124446_, p_124447_);
+            multimap.forEach((file, error) -> {
+                LOGGER.warn("Found validation problem in {}: {}", file, error);
             });
 //            throw new IllegalStateException("Failed to validate loot tables, see logs");
             LOGGER.warn("Failed to validate loot tables, see logs");
@@ -106,9 +106,7 @@ public class EMILootDirectDropsProvider implements DataProvider {
             LootTable loottable = entry.getValue();
             Path path = this.pathProvider.json(resourcekey1.location());
             return DataProvider.saveStable(output, provider, LootTable.DIRECT_CODEC, loottable, path);
-        }).toArray((x$0) -> {
-            return new CompletableFuture[x$0];
-        }));
+        }).toArray(CompletableFuture[]::new));
     }
 
     @Override

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/EMILootExcludedSyntheticLootModifierLootTablesProvider.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/EMILootExcludedSyntheticLootModifierLootTablesProvider.java
@@ -1,0 +1,49 @@
+package org.confluence.mod.common.data.gen;
+
+import net.minecraft.core.*;
+import net.minecraft.data.CachedOutput;
+import net.minecraft.data.DataProvider;
+import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
+import org.confluence.mod.common.data.gen.loot.modifiers.EMILootDataTableExclusions;
+import org.confluence.mod.common.data.gen.loot.modifiers.*;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+public class EMILootExcludedSyntheticLootModifierLootTablesProvider implements DataProvider {
+    private final PackOutput.PathProvider pathProvider;
+    private final List<Function<HolderLookup.Provider, SyntheticLootTableProvider>> providers;
+    private final CompletableFuture<HolderLookup.Provider> registries;
+
+
+    public EMILootExcludedSyntheticLootModifierLootTablesProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookup) {
+        this.pathProvider = output.createPathProvider(PackOutput.Target.DATA_PACK, "emi_loot_data");
+        this.providers = List.of(
+                AddEntityLootConfluenceSubProvider::new,
+                AddBlockLootConfluenceSubProvider::new,
+                AddChestLootConfluenceSubProvider::new
+        );
+        this.registries = lookup;
+    }
+
+    @Override
+    public CompletableFuture<?> run(CachedOutput cachedOutput) {
+        return this.registries.thenCompose((provider) -> {
+            var tableExclusions = new EMILootDataTableExclusions();
+            this.providers.forEach(i -> {
+                tableExclusions.excludedPaths.addAll(i.apply(provider).getSyntheticLootTablePaths());
+            });
+            Path path = this.pathProvider.json(ResourceLocation.fromNamespaceAndPath("emi_loot", "table_exclusions"));
+            return DataProvider.saveStable(cachedOutput, provider, EMILootDataTableExclusions.CODEC, tableExclusions, path);
+        });
+    }
+
+    @Override
+    public String getName() {
+        return "EMILoot Data Table Exclusions";
+    }
+}

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/ModDataGenerator.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/ModDataGenerator.java
@@ -60,6 +60,7 @@ public final class ModDataGenerator {
         generator.addProvider(server, new ModEnchantmentTagsProvider(output, lookup, helper));
         generator.addProvider(server, new ModRecipeSerializerTagsProvider(output, lookup, helper));
         generator.addProvider(server, new EMILootDirectDropsProvider(output, lookup));
+        generator.addProvider(server, new EMILootExcludedSyntheticLootModifierLootTablesProvider(output, lookup));
         generator.addProvider(server, new ModLootModifiersProvider(output, lookup));
     }
 }

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/AddBlockLootConfluenceSubProvider.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/AddBlockLootConfluenceSubProvider.java
@@ -35,7 +35,7 @@ import java.util.function.BiConsumer;
  *
  * @see org.confluence.mod.common.data.gen.ModLootModifiersProvider
  */
-public class AddBlockLootConfluenceSubProvider extends BlockLootSubProvider {
+public class AddBlockLootConfluenceSubProvider extends BlockLootSubProvider implements SyntheticLootTableProvider {
     private HolderLookup.Provider provider;
 
     public AddBlockLootConfluenceSubProvider(HolderLookup.Provider provider) {
@@ -214,6 +214,16 @@ public class AddBlockLootConfluenceSubProvider extends BlockLootSubProvider {
 
     public String getPath(ResourceLocation location) {
         return "with/" + location.getPath();
+    }
+
+    @Override
+    public List<String> getSyntheticLootTablePaths() {
+        var entries = getAddedBlocksLoot();
+        List<String> paths = new ArrayList<>();
+        for (var entry : entries) {
+            paths.add(Confluence.asResource(getPath(entry.block.getLootTable().location())).toString());
+        }
+        return paths;
     }
 
     public record AddedBlockLoot(Block block, LootTable.Builder lootTableBuilder) {}

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/AddChestLootConfluenceSubProvider.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/AddChestLootConfluenceSubProvider.java
@@ -26,7 +26,7 @@ import java.util.function.BiConsumer;
  * Generates chests loot tables into loot_modifier path specified by ModLootModifiersProvider i.e. confluence/loot_table/with/chests/bat.json
  * @see org.confluence.mod.common.data.gen.ModLootModifiersProvider
  */
-public class AddChestLootConfluenceSubProvider implements LootTableSubProvider {
+public class AddChestLootConfluenceSubProvider implements LootTableSubProvider, SyntheticLootTableProvider {
     public AddChestLootConfluenceSubProvider(HolderLookup.Provider provider) {
 
     }
@@ -397,6 +397,16 @@ public class AddChestLootConfluenceSubProvider implements LootTableSubProvider {
         for (var entry : entries) {
             output.accept(getResourceKey(entry.lootTable), entry.lootTableBuilder);
         }
+    }
+
+    @Override
+    public List<String> getSyntheticLootTablePaths() {
+        var paths = new ArrayList<String>();
+        var entries = getAddedEntitiesLoot();
+        for (var entry : entries) {
+            paths.add(Confluence.asResource(getPath(entry.lootTable)).toString());
+        }
+        return paths;
     }
 
     public record AddedChestLoot(ResourceKey<LootTable> lootTable, LootTable.Builder lootTableBuilder) {}

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/AddEntityLootConfluenceSubProvider.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/AddEntityLootConfluenceSubProvider.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
  * Generates entities loot tables into loot_modifier path specified by ModLootModifiersProvider i.e. confluence/loot_table/with/entities/bat.json
  * @see org.confluence.mod.common.data.gen.ModLootModifiersProvider
  */
-public class AddEntityLootConfluenceSubProvider extends EntityLootSubProvider {
+public class AddEntityLootConfluenceSubProvider extends EntityLootSubProvider implements SyntheticLootTableProvider {
     public AddEntityLootConfluenceSubProvider(HolderLookup.Provider registries) {
         super(FeatureFlags.REGISTRY.allFlags(), registries);
     }
@@ -273,6 +273,16 @@ public class AddEntityLootConfluenceSubProvider extends EntityLootSubProvider {
         if (!accessor.getMap().isEmpty()) {
             throw new IllegalStateException("Created loot tables for entities not supported by datapack: " + accessor.getMap().keySet());
         }
+    }
+
+    @Override
+    public List<String> getSyntheticLootTablePaths() {
+        var entries = getAddedEntitiesLoot();
+        List<String> paths = new ArrayList<>();
+        for (var entry : entries) {
+            paths.add(Confluence.asResource(getPath(entry.entityType)).toString());
+        }
+        return paths;
     }
 
     public record AddedEntityLoot(EntityType<?> entityType, LootTable.Builder lootTableBuilder) {}

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/EMILootDataTableExclusions.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/EMILootDataTableExclusions.java
@@ -1,0 +1,26 @@
+package org.confluence.mod.common.data.gen.loot.modifiers;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EMILootDataTableExclusions {
+    public EMILootDataTableExclusions() {
+        this.excludedPaths = new ArrayList<>();
+    }
+
+    EMILootDataTableExclusions(List<String> excludedPaths) {
+        this.excludedPaths = excludedPaths;
+    }
+
+    public static Codec<EMILootDataTableExclusions> CODEC;
+    public List <String> excludedPaths;
+
+    static {
+        CODEC = RecordCodecBuilder.create((tableExclusionsInstance) -> tableExclusionsInstance.group(
+                Codec.list(Codec.STRING).fieldOf("exclusions").forGetter((instance) -> instance.excludedPaths)
+        ).apply(tableExclusionsInstance, EMILootDataTableExclusions::new));
+    }
+}

--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/SyntheticLootTableProvider.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/common/data/gen/loot/modifiers/SyntheticLootTableProvider.java
@@ -1,0 +1,7 @@
+package org.confluence.mod.common.data.gen.loot.modifiers;
+
+import java.util.List;
+
+public interface SyntheticLootTableProvider {
+    List<String> getSyntheticLootTablePaths();
+}


### PR DESCRIPTION
Synthetic loot tables for loot modifiers are parsed by EMILoot that leads to having such broken recipies.
This PR adds such loot tables to the dedicated file to exclude them from display
<img width="410" height="199" alt="Screenshot 2026-01-02 033556" src="https://github.com/user-attachments/assets/c2fe9a30-069e-49e8-9555-841ae437ad9f" />

Docs: https://github.com/fzzyhmstrs/EMI_loot/wiki/Table-Exclusions
