### PR TITLE
Effect switchable when JEI is not installed.

### DIFF
--- a/ConfluenceOtherworld/src/main/java/org/confluence/mod/mixin/client/gui/screens/inventory/EffectRenderingInventoryScreenMixin.java
+++ b/ConfluenceOtherworld/src/main/java/org/confluence/mod/mixin/client/gui/screens/inventory/EffectRenderingInventoryScreenMixin.java
@@ -4,9 +4,13 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.neoforged.neoforge.common.util.TriState;
 import org.confluence.mod.mixed.IAbstractContainerScreen;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,9 +20,13 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EffectRenderingInventoryScreen.class)
-public abstract class EffectRenderingInventoryScreenMixin implements IAbstractContainerScreen {
+public abstract class EffectRenderingInventoryScreenMixin<T extends AbstractContainerMenu> extends AbstractContainerScreen<T> implements IAbstractContainerScreen {
     @Unique
     private boolean confluence$mouseClicked = false;
+
+    public EffectRenderingInventoryScreenMixin(T menu, Inventory playerInventory, Component title) {
+        super(menu, playerInventory, title);
+    }
 
     @Override
     public TriState confluence$onMouseClicked(double mouseX, double mouseY, int button) {
@@ -27,14 +35,38 @@ public abstract class EffectRenderingInventoryScreenMixin implements IAbstractCo
     }
 
     @Inject(method = "renderEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;renderTooltip(Lnet/minecraft/client/gui/Font;Ljava/util/List;Ljava/util/Optional;II)V", shift = At.Shift.AFTER))
-    private void switchEnabled(CallbackInfo ci, @Local(ordinal = 0) MobEffectInstance instance) {
+    private void switchEnabled(GuiGraphics guiGraphics, int mouseX, int mouseY, CallbackInfo ci, @Local(ordinal = 0) MobEffectInstance instance) {
         if (confluence$mouseClicked) {
             IAbstractContainerScreen.switchEnabled(instance);
         }
     }
 
+    @Inject(
+            method = "renderEffects",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen;renderLabels(Lnet/minecraft/client/gui/GuiGraphics;IILjava/lang/Iterable;)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void switchEnabled(GuiGraphics guiGraphics, int mouseX, int mouseY, CallbackInfo ci, @Local Iterable<MobEffectInstance> iterable, @Local(name = "k") int k) {
+        int l = this.topPos;
+        MobEffectInstance instance = null;
+        for(MobEffectInstance ins : iterable) {
+            if (mouseY >= l && mouseY <= l + k) {
+                instance = ins;
+            }
+            l += k;
+        }
+        if(instance != null) {
+            if (confluence$mouseClicked) {
+                IAbstractContainerScreen.switchEnabled(instance);
+            }
+        }
+    }
+
     @Inject(method = "renderEffects", at = @At("TAIL"))
-    private void reset(CallbackInfo ci) {
+    private void reset(GuiGraphics guiGraphics, int mouseX, int mouseY, CallbackInfo ci) {
         this.confluence$mouseClicked = false;
     }
 


### PR DESCRIPTION
To be precise, now you can toggle the effect even when there's no effect tooltip.

When JEI is installed, the effect will render as a square, and then they have tooltips.
But when JEI isn't installed, there won't be any tooltips, so the switch feature can't be used.

准确的说，现在可以在没有药水效果tooltip的时候开关它了
装了JEI之后，药水效果会被jei挤的只渲染一个正方形，这时候就会有tooltip，才可以开关它
但是当没有安装JEI，药水效果会以条状长方形渲染，是没有tooltip的，开关不了它

pr修复了这个问题